### PR TITLE
Silly config example using attrs and cattrs.

### DIFF
--- a/attr_config/attrs_example.py
+++ b/attr_config/attrs_example.py
@@ -1,0 +1,16 @@
+import attr
+import cattr
+import yaml
+
+
+@attr.s
+class MyConfig(object):
+    version = attr.ib(str)
+    hdfs_server = attr.ib(str)
+    mlflow_uri = attr.ib(str)
+
+
+def load_config(path):
+    with open(path) as config_f:
+        config = yaml.safe_load(config_f)
+    return cattr.structure(config, MyConfig)

--- a/attr_config/silly_config.yaml
+++ b/attr_config/silly_config.yaml
@@ -1,0 +1,3 @@
+version: "0.1"
+hdfs_server: "hdfs://mycluster"
+mlflow_uri: "http://1.1.1.1"

--- a/attr_config/test_silly_config.py
+++ b/attr_config/test_silly_config.py
@@ -1,0 +1,15 @@
+import pytest
+
+from attr_config.attrs_example import load_config
+
+
+@pytest.mark.parametrize(
+    "field_name,expected_value",
+    [('hdfs_server', 'hdfs://mycluster'),
+     ('version', '0.1'),
+     ('mlflow_uri', 'http://1.1.1.1')]
+)
+def test_config_attributes(field_name, expected_value):
+    config = load_config('silly_config.yaml')
+    field_value = getattr(config, field_name)
+    assert field_value == expected_value


### PR DESCRIPTION
Main goal:

- Create toy example of using attrs instead of dataclasses
- Use cattrs. unstructure to take care of the dict parsing